### PR TITLE
Morning Call and Night Debrief feature

### DIFF
--- a/src/main/java/seedu/jelphabot/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/jelphabot/commons/core/GuiSettings.java
@@ -23,6 +23,12 @@ public class GuiSettings implements Serializable {
         windowCoordinates = null; // null represent no coordinates
     }
 
+    public GuiSettings(double windowWidth, double windowHeight) {
+        this.windowWidth = windowWidth;
+        this.windowHeight = windowHeight;
+        windowCoordinates = null;
+    }
+
     public GuiSettings(double windowWidth, double windowHeight, int xPosition, int yPosition) {
         this.windowWidth = windowWidth;
         this.windowHeight = windowHeight;

--- a/src/main/java/seedu/jelphabot/logic/Logic.java
+++ b/src/main/java/seedu/jelphabot/logic/Logic.java
@@ -51,6 +51,11 @@ public interface Logic {
     GuiSettings getGuiSettings();
 
     /**
+     * Returns the GUI settings for a popup window
+     */
+    GuiSettings getPopUpWindowGuiSettings();
+
+    /**
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);

--- a/src/main/java/seedu/jelphabot/logic/Logic.java
+++ b/src/main/java/seedu/jelphabot/logic/Logic.java
@@ -34,6 +34,12 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of tasks */
     ObservableList<Task> getFilteredTaskList();
 
+    /** Returns an unmodifiable view of the completed tasks in the task list */
+    ObservableList<Task> getFilteredByCompleteTaskList();
+
+    /** Returns an unmodifiable view of the incomplete tasks in the task list */
+    ObservableList<Task> getFilteredByIncompleteTaskList();
+
     /**
      * Returns the user prefs' address book file path.
      */

--- a/src/main/java/seedu/jelphabot/logic/LogicManager.java
+++ b/src/main/java/seedu/jelphabot/logic/LogicManager.java
@@ -82,6 +82,11 @@ public class LogicManager implements Logic {
     }
 
     @Override
+    public GuiSettings getPopUpWindowGuiSettings() {
+        return model.getPopUpWindowGuiSettings();
+    }
+
+    @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
     }

--- a/src/main/java/seedu/jelphabot/logic/LogicManager.java
+++ b/src/main/java/seedu/jelphabot/logic/LogicManager.java
@@ -62,6 +62,16 @@ public class LogicManager implements Logic {
     }
 
     @Override
+    public ObservableList<Task> getFilteredByCompleteTaskList() {
+        return model.getFilteredByCompleteTaskList();
+    }
+
+    @Override
+    public ObservableList<Task> getFilteredByIncompleteTaskList() {
+        return model.getFilteredByIncompleteTaskList();
+    }
+
+    @Override
     public Path getJelphaBotFilePath() {
         return model.getJelphaBotFilePath();
     }

--- a/src/main/java/seedu/jelphabot/model/Model.java
+++ b/src/main/java/seedu/jelphabot/model/Model.java
@@ -80,6 +80,12 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered task list */
     ObservableList<Task> getFilteredTaskList();
 
+    /** Returns an unmodifiable view of the completed tasks in the task list */
+    ObservableList<Task> getFilteredByCompleteTaskList();
+
+    /** Returns an unmodifiable view of the incomplete tasks in the task list */
+    ObservableList<Task> getFilteredByIncompleteTaskList();
+
     /**
      * Updates the filter of the filtered task list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.

--- a/src/main/java/seedu/jelphabot/model/Model.java
+++ b/src/main/java/seedu/jelphabot/model/Model.java
@@ -31,6 +31,11 @@ public interface Model {
     GuiSettings getGuiSettings();
 
     /**
+     * Returns the GUI settings for a popup window
+     */
+    GuiSettings getPopUpWindowGuiSettings();
+
+    /**
      * Sets the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);

--- a/src/main/java/seedu/jelphabot/model/ModelManager.java
+++ b/src/main/java/seedu/jelphabot/model/ModelManager.java
@@ -63,6 +63,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public GuiSettings getPopUpWindowGuiSettings() {
+        return userPrefs.getPopUpWindowGuiSettings();
+    }
+
+    @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         requireNonNull(guiSettings);
         userPrefs.setGuiSettings(guiSettings);

--- a/src/main/java/seedu/jelphabot/model/ModelManager.java
+++ b/src/main/java/seedu/jelphabot/model/ModelManager.java
@@ -12,6 +12,8 @@ import javafx.collections.transformation.FilteredList;
 import seedu.jelphabot.commons.core.GuiSettings;
 import seedu.jelphabot.commons.core.LogsCenter;
 import seedu.jelphabot.model.task.Task;
+import seedu.jelphabot.model.task.TaskCompletedPredicate;
+import seedu.jelphabot.model.task.TaskIncompletePredicate;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -124,6 +126,16 @@ public class ModelManager implements Model {
     @Override
     public ObservableList<Task> getFilteredTaskList() {
         return filteredTasks;
+    }
+
+    public ObservableList<Task> getFilteredByIncompleteTaskList() {
+        TaskIncompletePredicate predicate = new TaskIncompletePredicate();
+        return new FilteredList<>(filteredTasks, predicate);
+    }
+
+    public ObservableList<Task> getFilteredByCompleteTaskList() {
+        TaskCompletedPredicate predicate = new TaskCompletedPredicate();
+        return new FilteredList<>(filteredTasks, predicate);
     }
 
     @Override

--- a/src/main/java/seedu/jelphabot/model/UserPrefs.java
+++ b/src/main/java/seedu/jelphabot/model/UserPrefs.java
@@ -42,6 +42,11 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         return guiSettings;
     }
 
+    public GuiSettings getPopUpWindowGuiSettings() {
+        // create a new GuiSettings object with smaller dimensions than the default
+        return new GuiSettings(540.0, 400.0);
+    }
+
     public void setGuiSettings(GuiSettings guiSettings) {
         requireNonNull(guiSettings);
         this.guiSettings = guiSettings;

--- a/src/main/java/seedu/jelphabot/ui/MainWindow.java
+++ b/src/main/java/seedu/jelphabot/ui/MainWindow.java
@@ -21,8 +21,7 @@ import seedu.jelphabot.logic.parser.exceptions.ParseException;
  * The Main Window. Provides the basic application layout containing a menu bar
  * and space where other JavaFX elements can be placed.
  */
-public class
-MainWindow extends UiPart<Stage> {
+public class MainWindow extends UiPart<Stage> {
 
     private static final String FXML = "MainWindow.fxml";
 

--- a/src/main/java/seedu/jelphabot/ui/MainWindow.java
+++ b/src/main/java/seedu/jelphabot/ui/MainWindow.java
@@ -21,7 +21,8 @@ import seedu.jelphabot.logic.parser.exceptions.ParseException;
  * The Main Window. Provides the basic application layout containing a menu bar
  * and space where other JavaFX elements can be placed.
  */
-public class MainWindow extends UiPart<Stage> {
+public class
+MainWindow extends UiPart<Stage> {
 
     private static final String FXML = "MainWindow.fxml";
 

--- a/src/main/java/seedu/jelphabot/ui/MainWindow.java
+++ b/src/main/java/seedu/jelphabot/ui/MainWindow.java
@@ -12,6 +12,7 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.jelphabot.commons.core.GuiSettings;
 import seedu.jelphabot.commons.core.LogsCenter;
+import seedu.jelphabot.commons.util.StringUtil;
 import seedu.jelphabot.logic.Logic;
 import seedu.jelphabot.logic.commands.CommandResult;
 import seedu.jelphabot.logic.commands.exceptions.CommandException;
@@ -161,6 +162,18 @@ public class MainWindow extends UiPart<Stage> {
         logic.setGuiSettings(guiSettings);
         helpWindow.hide();
         primaryStage.hide();
+
+        // after the MainWindow is closed,
+        // initialise and show the night debrief window
+        Stage nightDebriefStage = new Stage();
+
+        try {
+            NightDebriefWindow nightDebrief = new NightDebriefWindow(nightDebriefStage, logic);
+            nightDebrief.show();
+            nightDebrief.fillWindow();
+        } catch (Throwable e) {
+            logger.severe(StringUtil.getDetails(e));
+        }
     }
 
     public TaskListPanel getTaskListPanel() {
@@ -193,4 +206,6 @@ public class MainWindow extends UiPart<Stage> {
             throw e;
         }
     }
+
+
 }

--- a/src/main/java/seedu/jelphabot/ui/MorningCallWindow.java
+++ b/src/main/java/seedu/jelphabot/ui/MorningCallWindow.java
@@ -2,12 +2,14 @@ package seedu.jelphabot.ui;
 
 import java.util.logging.Logger;
 
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.jelphabot.commons.core.GuiSettings;
 import seedu.jelphabot.commons.core.LogsCenter;
 import seedu.jelphabot.logic.Logic;
+import seedu.jelphabot.model.task.Task;
 
 public class MorningCallWindow extends UiPart<Stage> {
     private static final String FXML = "MorningCallWindow.fxml";
@@ -38,6 +40,13 @@ public class MorningCallWindow extends UiPart<Stage> {
 
         //setAcclerators();
 
+    }
+
+    void fillWindow() {
+        // get the list of Incomplete tasks
+        ObservableList<Task> taskList = logic.getFilteredByIncompleteTaskList();
+        taskListPanel = new TaskListPanel(taskList);
+        taskListPanelPlaceholder.getChildren().add(taskListPanel.getRoot());
     }
 
     public TaskListPanel getTaskListPanel() {

--- a/src/main/java/seedu/jelphabot/ui/MorningCallWindow.java
+++ b/src/main/java/seedu/jelphabot/ui/MorningCallWindow.java
@@ -26,7 +26,7 @@ public class MorningCallWindow extends UiPart<Stage> {
     private Stage morningCallStage;
     private Logic logic;
 
-    // Ui parts that are required to be in this Ui contioner
+    // Ui parts that are required to be in this Ui container
     private TaskListPanel taskListPanel;
     // resultDisplay box from MainWindow will be used to
     // display the message of the "morning call" to user

--- a/src/main/java/seedu/jelphabot/ui/MorningCallWindow.java
+++ b/src/main/java/seedu/jelphabot/ui/MorningCallWindow.java
@@ -54,6 +54,9 @@ public class MorningCallWindow extends UiPart<Stage> {
 
     }
 
+    /**
+     * Fills the placeholders of this window
+     */
     void fillWindow() {
         // get the list of Incomplete tasks
         ObservableList<Task> taskList = logic.getFilteredByIncompleteTaskList();

--- a/src/main/java/seedu/jelphabot/ui/MorningCallWindow.java
+++ b/src/main/java/seedu/jelphabot/ui/MorningCallWindow.java
@@ -1,0 +1,57 @@
+package seedu.jelphabot.ui;
+
+import java.util.logging.Logger;
+
+import javafx.fxml.FXML;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import seedu.jelphabot.commons.core.GuiSettings;
+import seedu.jelphabot.commons.core.LogsCenter;
+import seedu.jelphabot.logic.Logic;
+
+public class MorningCallWindow extends UiPart<Stage> {
+    private static final String FXML = "MorningCallWindow.fxml";
+
+    private final Logger logger = LogsCenter.getLogger(getClass());
+
+    private Stage morningCallStage;
+    private Logic logic;
+
+    // Ui parts that are required to be in this Ui contioner
+    private TaskListPanel taskListPanel;
+
+    @FXML
+    private StackPane taskListPanelPlaceholder;
+
+    public MorningCallWindow(Stage morningCallStage) {
+        super(FXML, morningCallStage);
+
+        // set dependencies
+        this.morningCallStage = morningCallStage;
+
+        // configure the UI
+        // for now, set the size to be the same as MainWindow
+        // TODO: configure settings to customize the size of the window
+        setWindowDefaultSize(logic.getGuiSettings());
+
+        setAcclerators();
+
+    }
+
+    public TaskListPanel getTaskListPanel() {
+        return taskListPanel;
+    }
+
+    /**
+     * Sets the default size based on {@code guiSettings}.
+     */
+    private void setWindowDefaultSize(GuiSettings guiSettings) {
+        morningCallStage.setHeight(guiSettings.getWindowHeight());
+        morningCallStage.setWidth(guiSettings.getWindowWidth());
+        if (guiSettings.getWindowCoordinates() != null) {
+            morningCallStage.setX(guiSettings.getWindowCoordinates().getX());
+            morningCallStage.setY(guiSettings.getWindowCoordinates().getY());
+        }
+    }
+
+}

--- a/src/main/java/seedu/jelphabot/ui/MorningCallWindow.java
+++ b/src/main/java/seedu/jelphabot/ui/MorningCallWindow.java
@@ -11,8 +11,15 @@ import seedu.jelphabot.commons.core.LogsCenter;
 import seedu.jelphabot.logic.Logic;
 import seedu.jelphabot.model.task.Task;
 
+/**
+ * The MorningCall Window that is shown upon the app startup. Follows the
+ * styling specified in MainWindow.
+ */
 public class MorningCallWindow extends UiPart<Stage> {
+
     private static final String FXML = "MorningCallWindow.fxml";
+
+    private static final String MORNING_CALL_STRING = "Hello! Here are your incomplete tasks so far!";
 
     private final Logger logger = LogsCenter.getLogger(getClass());
 
@@ -21,9 +28,16 @@ public class MorningCallWindow extends UiPart<Stage> {
 
     // Ui parts that are required to be in this Ui contioner
     private TaskListPanel taskListPanel;
+    // resultDisplay box from MainWindow will be used to
+    // display the message of the "morning call" to user
+    // TODO: customise this box to be something other than resultDisplay
+    private ResultDisplay resultDisplay;
 
     @FXML
     private StackPane taskListPanelPlaceholder;
+
+    @FXML
+    private StackPane resultDisplayPlaceholder;
 
     public MorningCallWindow(Stage morningCallStage, Logic logic) {
 
@@ -33,9 +47,7 @@ public class MorningCallWindow extends UiPart<Stage> {
         // set dependencies
         this.morningCallStage = morningCallStage;
         this.logic = logic;
-        // configure the UI
-        // for now, set the size to be the same as MainWindow
-        // TODO: configure settings to customize the size of the window, not follow MainWindow dims
+        // configure the UI to custom dimensions
         setWindowDefaultSize(logic.getPopUpWindowGuiSettings());
 
         //setAcclerators();
@@ -47,6 +59,11 @@ public class MorningCallWindow extends UiPart<Stage> {
         ObservableList<Task> taskList = logic.getFilteredByIncompleteTaskList();
         taskListPanel = new TaskListPanel(taskList);
         taskListPanelPlaceholder.getChildren().add(taskListPanel.getRoot());
+
+        // initialise resultDisplay
+        resultDisplay = new ResultDisplay();
+        resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
+        resultDisplay.setFeedbackToUser(MORNING_CALL_STRING);
     }
 
     public TaskListPanel getTaskListPanel() {

--- a/src/main/java/seedu/jelphabot/ui/MorningCallWindow.java
+++ b/src/main/java/seedu/jelphabot/ui/MorningCallWindow.java
@@ -23,23 +23,30 @@ public class MorningCallWindow extends UiPart<Stage> {
     @FXML
     private StackPane taskListPanelPlaceholder;
 
-    public MorningCallWindow(Stage morningCallStage) {
+    public MorningCallWindow(Stage morningCallStage, Logic logic) {
+
         super(FXML, morningCallStage);
 
+        logger.info("Initialising morningCallWindow");
         // set dependencies
         this.morningCallStage = morningCallStage;
-
+        this.logic = logic;
         // configure the UI
         // for now, set the size to be the same as MainWindow
-        // TODO: configure settings to customize the size of the window
+        // TODO: configure settings to customize the size of the window, not follow MainWindow dims
         setWindowDefaultSize(logic.getGuiSettings());
 
-        setAcclerators();
+        //setAcclerators();
 
     }
 
     public TaskListPanel getTaskListPanel() {
         return taskListPanel;
+    }
+
+    void show() {
+        logger.info("Showing morningCallStage");
+        morningCallStage.show();
     }
 
     /**
@@ -52,6 +59,12 @@ public class MorningCallWindow extends UiPart<Stage> {
             morningCallStage.setX(guiSettings.getWindowCoordinates().getX());
             morningCallStage.setY(guiSettings.getWindowCoordinates().getY());
         }
+    }
+
+    @FXML
+    private void closeButtonAction() {
+        logger.info("Close Button pressed. Closing morningCallWindow");
+        morningCallStage.close();
     }
 
 }

--- a/src/main/java/seedu/jelphabot/ui/MorningCallWindow.java
+++ b/src/main/java/seedu/jelphabot/ui/MorningCallWindow.java
@@ -36,7 +36,7 @@ public class MorningCallWindow extends UiPart<Stage> {
         // configure the UI
         // for now, set the size to be the same as MainWindow
         // TODO: configure settings to customize the size of the window, not follow MainWindow dims
-        setWindowDefaultSize(logic.getGuiSettings());
+        setWindowDefaultSize(logic.getPopUpWindowGuiSettings());
 
         //setAcclerators();
 

--- a/src/main/java/seedu/jelphabot/ui/NightDebriefWindow.java
+++ b/src/main/java/seedu/jelphabot/ui/NightDebriefWindow.java
@@ -11,10 +11,14 @@ import seedu.jelphabot.commons.core.LogsCenter;
 import seedu.jelphabot.logic.Logic;
 import seedu.jelphabot.model.task.Task;
 
+/**
+ * The NightDebrief Window that is shown upon the app exiting.
+ * Follows the styling specified in MainWindow.
+ */
 public class NightDebriefWindow extends UiPart<Stage> {
     private static final String FXML = "NightDebriefWindow.fxml";
 
-    private static final String NIGHT_DEBRIEF_STRING = "Goodbye! Before you go, "
+    private static final String NIGHT_DEBRIEF_STRING = "Goodbye! Before you go, \n"
                                                            + "here are the tasks that you have completed!";
 
     private final Logger logger = LogsCenter.getLogger(getClass());
@@ -49,6 +53,9 @@ public class NightDebriefWindow extends UiPart<Stage> {
         setWindowDefaultSize(logic.getPopUpWindowGuiSettings());
     }
 
+    /**
+     * Fills the placeholders of this window
+     */
     void fillWindow() {
         // get the list of completed tasks
         ObservableList<Task> taskList = logic.getFilteredByCompleteTaskList();
@@ -81,5 +88,11 @@ public class NightDebriefWindow extends UiPart<Stage> {
             nightDebriefStage.setX(guiSettings.getWindowCoordinates().getX());
             nightDebriefStage.setY(guiSettings.getWindowCoordinates().getY());
         }
+    }
+
+    @FXML
+    private void closeButtonAction() {
+        logger.info("Close Button pressed. Closing nightDebriefStage.");
+        nightDebriefStage.close();
     }
 }

--- a/src/main/java/seedu/jelphabot/ui/NightDebriefWindow.java
+++ b/src/main/java/seedu/jelphabot/ui/NightDebriefWindow.java
@@ -1,0 +1,85 @@
+package seedu.jelphabot.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import seedu.jelphabot.commons.core.GuiSettings;
+import seedu.jelphabot.commons.core.LogsCenter;
+import seedu.jelphabot.logic.Logic;
+import seedu.jelphabot.model.task.Task;
+
+public class NightDebriefWindow extends UiPart<Stage> {
+    private static final String FXML = "NightDebriefWindow.fxml";
+
+    private static final String NIGHT_DEBRIEF_STRING = "Goodbye! Before you go, "
+                                                           + "here are the tasks that you have completed!";
+
+    private final Logger logger = LogsCenter.getLogger(getClass());
+
+    private Stage nightDebriefStage;
+    private Logic logic;
+
+    // Ui parts that are required to be in this Ui container
+    private TaskListPanel taskListPanel;
+
+    // resultDisplay box from MainWindow will be used to
+    // display the message of the "night debrief" to the user
+    // TODO: customise this box to be something other than resultDisplay
+    private ResultDisplay resultDisplay;
+
+    @FXML
+    private StackPane taskListPanelPlaceholder;
+
+    @FXML
+    private StackPane resultDisplayPlaceholder;
+
+    public NightDebriefWindow(Stage nightDebriefStage, Logic logic) {
+        super(FXML, nightDebriefStage);
+
+        logger.info("Initialising NightDebriefWindow");
+
+        //set dependencies
+        this.nightDebriefStage = nightDebriefStage;
+        this.logic = logic;
+
+        //configure the UI to custom dimensions
+        setWindowDefaultSize(logic.getPopUpWindowGuiSettings());
+    }
+
+    void fillWindow() {
+        // get the list of completed tasks
+        ObservableList<Task> taskList = logic.getFilteredByCompleteTaskList();
+        taskListPanel = new TaskListPanel(taskList);
+        taskListPanelPlaceholder.getChildren().add(taskListPanel.getRoot());
+
+        //initialise resultDisplay
+        resultDisplay = new ResultDisplay();
+        resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
+        resultDisplay.setFeedbackToUser(NIGHT_DEBRIEF_STRING);
+
+    }
+
+    public TaskListPanel getTaskListPanel() {
+        return taskListPanel;
+    }
+
+    void show() {
+        logger.info("Showing nightDebriefStage");
+        nightDebriefStage.show();
+    }
+
+    /**
+     * Sets the default size based on {@code guiSettings}.
+     */
+    private void setWindowDefaultSize(GuiSettings guiSettings) {
+        nightDebriefStage.setHeight(guiSettings.getWindowHeight());
+        nightDebriefStage.setWidth(guiSettings.getWindowWidth());
+        if (guiSettings.getWindowCoordinates() != null) {
+            nightDebriefStage.setX(guiSettings.getWindowCoordinates().getX());
+            nightDebriefStage.setY(guiSettings.getWindowCoordinates().getY());
+        }
+    }
+}

--- a/src/main/java/seedu/jelphabot/ui/UiManager.java
+++ b/src/main/java/seedu/jelphabot/ui/UiManager.java
@@ -24,6 +24,7 @@ public class UiManager implements Ui {
 
     private Logic logic;
     private MainWindow mainWindow;
+    private MorningCallWindow morningCallWindow;
 
     public UiManager(Logic logic) {
         super();
@@ -44,6 +45,10 @@ public class UiManager implements Ui {
             mainWindow = new MainWindow(primaryStage, logic);
             mainWindow.show(); //This should be called before creating other UI parts
             mainWindow.fillInnerParts();
+
+            // show morningCallWindow
+            morningCallWindow = new MorningCallWindow(morningCallStage, logic);
+            morningCallWindow.show();
 
         } catch (Throwable e) {
             logger.severe(StringUtil.getDetails(e));

--- a/src/main/java/seedu/jelphabot/ui/UiManager.java
+++ b/src/main/java/seedu/jelphabot/ui/UiManager.java
@@ -37,6 +37,9 @@ public class UiManager implements Ui {
         //Set the application icon.
         primaryStage.getIcons().add(getImage(ICON_APPLICATION));
 
+        // create second stage for MorningCallWindow
+        Stage morningCallStage = new Stage();
+
         try {
             mainWindow = new MainWindow(primaryStage, logic);
             mainWindow.show(); //This should be called before creating other UI parts

--- a/src/main/java/seedu/jelphabot/ui/UiManager.java
+++ b/src/main/java/seedu/jelphabot/ui/UiManager.java
@@ -49,6 +49,7 @@ public class UiManager implements Ui {
             // show morningCallWindow
             morningCallWindow = new MorningCallWindow(morningCallStage, logic);
             morningCallWindow.show();
+            morningCallWindow.fillWindow();
 
         } catch (Throwable e) {
             logger.severe(StringUtil.getDetails(e));

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -14,7 +14,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="JelphaBot" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="JelphaBot" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml">
     <icons>
         <Image url="@/images/address_book_32.png" />
     </icons>

--- a/src/main/resources/view/MorningCallWindow.fxml
+++ b/src/main/resources/view/MorningCallWindow.fxml
@@ -9,7 +9,7 @@
 <?import javafx.stage.*?>
 
 <fx:root minHeight="540" minWidth="400" title="JelphaBot" type="javafx.stage.Stage"
-         xmlns="http://javafx.com/javafx/10.0.2-internal" xmlns:fx="http://javafx.com/fxml/1">
+         xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml">
     <icons>
         <Image url="@/images/address_book_32.png" />
     </icons>
@@ -28,11 +28,17 @@
                                 <Insets left="10" right="10" top="10" />
                             </padding>
                             <StackPane fx:id="taskListPanelPlaceholder" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" VBox.vgrow="ALWAYS" />
-                     <ButtonBar maxHeight="40.0" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="40.0" prefWidth="80.0">
-                       <buttons>
-                         <Button fx:id="closeButton" alignment="CENTER" contentDisplay="CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="0.0" mnemonicParsing="false" onAction="#closeButtonAction" prefHeight="31.0" text="OK" textAlignment="CENTER" />
-                       </buttons>
-                     </ButtonBar>
+                            <StackPane fx:id="resultDisplayPlaceholder" maxHeight="50" minHeight="50"
+                                       prefHeight="50" styleClass="pane-with-border" VBox.vgrow="NEVER">
+                                <padding>
+                                    <Insets bottom="5" left="10" right="10" top="5" />
+                                </padding>
+                            </StackPane>
+                            <ButtonBar maxHeight="40.0" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="40.0" prefWidth="80.0">
+                               <buttons>
+                                 <Button fx:id="closeButton" alignment="CENTER" contentDisplay="CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="0.0" mnemonicParsing="false" onAction="#closeButtonAction" prefHeight="31.0" text="OK" textAlignment="CENTER" />
+                               </buttons>
+                            </ButtonBar>
                         </VBox>
                     </children>
                 </AnchorPane>

--- a/src/main/resources/view/MorningCallWindow.fxml
+++ b/src/main/resources/view/MorningCallWindow.fxml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.Scene?>
+<?import javafx.stage.Stage?>
+<?import java.net.URL?>
+<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="JelphaBot" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
+    <icons>
+        <Image url="@/images/address_book_32.png" />
+    </icons>
+    <scene>
+        <Scene>
+            <stylesheets>
+                <URL value="@DarkTheme.css" />
+                <URL value="@Extensions.css" />
+            </stylesheets>
+            <VBox>
+                <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
+                    <children>
+                        <VBox fx:id="taskList" minWidth="340" prefWidth="340.0" styleClass="pane-with-border" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                            <padding>
+                                <Insets bottom="10" left="10" right="10" top="10" />
+                            </padding>
+                            <StackPane fx:id="taskListPanelPlaceholder" VBox.vgrow="ALWAYS" />
+                        </VBox>
+                    </children>
+                </AnchorPane>
+            </VBox>
+        </Scene>
+    </scene>
+</fx:root>

--- a/src/main/resources/view/MorningCallWindow.fxml
+++ b/src/main/resources/view/MorningCallWindow.fxml
@@ -8,7 +8,8 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.stage.*?>
 
-<fx:root minHeight="600" minWidth="450" title="JelphaBot" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/10.0.2-internal" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="540" minWidth="400" title="JelphaBot" type="javafx.stage.Stage"
+         xmlns="http://javafx.com/javafx/10.0.2-internal" xmlns:fx="http://javafx.com/fxml/1">
     <icons>
         <Image url="@/images/address_book_32.png" />
     </icons>
@@ -19,16 +20,17 @@
                 <URL value="@Extensions.css" />
             </stylesheets>
             <VBox>
-                <AnchorPane prefHeight="560.0" prefWidth="600.0">
+                <AnchorPane prefHeight="500.0" prefWidth="400.0">
                     <children>
-                        <VBox fx:id="taskList" minWidth="340" prefWidth="340.0" styleClass="pane-with-border" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                        <VBox fx:id="taskList" minWidth="140" prefWidth="140.0" styleClass="pane-with-border"
+                              AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                             <padding>
-                                <Insets bottom="10" left="10" right="10" top="10" />
+                                <Insets left="10" right="10" top="10" />
                             </padding>
                             <StackPane fx:id="taskListPanelPlaceholder" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" VBox.vgrow="ALWAYS" />
                      <ButtonBar maxHeight="40.0" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="40.0" prefWidth="80.0">
                        <buttons>
-                         <Button fx:id="closeButton" alignment="CENTER" contentDisplay="CENTER" layoutX="-10.0" layoutY="-10.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="0.0" mnemonicParsing="false" onAction="#closeButtonAction" prefHeight="31.0" text="OK" textAlignment="CENTER" />
+                         <Button fx:id="closeButton" alignment="CENTER" contentDisplay="CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="0.0" mnemonicParsing="false" onAction="#closeButtonAction" prefHeight="31.0" text="OK" textAlignment="CENTER" />
                        </buttons>
                      </ButtonBar>
                         </VBox>

--- a/src/main/resources/view/MorningCallWindow.fxml
+++ b/src/main/resources/view/MorningCallWindow.fxml
@@ -19,21 +19,21 @@
                 <URL value="@Extensions.css" />
             </stylesheets>
             <VBox>
-                <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
+                <AnchorPane prefHeight="560.0" prefWidth="600.0">
                     <children>
                         <VBox fx:id="taskList" minWidth="340" prefWidth="340.0" styleClass="pane-with-border" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                             <padding>
                                 <Insets bottom="10" left="10" right="10" top="10" />
                             </padding>
-                            <StackPane fx:id="taskListPanelPlaceholder" VBox.vgrow="ALWAYS" />
+                            <StackPane fx:id="taskListPanelPlaceholder" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" VBox.vgrow="ALWAYS" />
+                     <ButtonBar maxHeight="40.0" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="40.0" prefWidth="80.0">
+                       <buttons>
+                         <Button fx:id="closeButton" alignment="CENTER" contentDisplay="CENTER" layoutX="-10.0" layoutY="-10.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="0.0" mnemonicParsing="false" onAction="#closeButtonAction" prefHeight="31.0" text="OK" textAlignment="CENTER" />
+                       </buttons>
+                     </ButtonBar>
                         </VBox>
                     </children>
                 </AnchorPane>
-            <ButtonBar prefHeight="40.0" prefWidth="200.0">
-              <buttons>
-                <Button fx:id="closeButton" onAction="#closeButtonAction" mnemonicParsing="false" text="OK" />
-              </buttons>
-            </ButtonBar>
             </VBox>
         </Scene>
     </scene>

--- a/src/main/resources/view/MorningCallWindow.fxml
+++ b/src/main/resources/view/MorningCallWindow.fxml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.image.Image?>
+<?import java.net.*?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.image.*?>
 <?import javafx.scene.layout.*?>
-<?import javafx.scene.Scene?>
-<?import javafx.stage.Stage?>
-<?import java.net.URL?>
-<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="JelphaBot" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
+<?import javafx.stage.*?>
+
+<fx:root minHeight="600" minWidth="450" title="JelphaBot" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/10.0.2-internal" xmlns:fx="http://javafx.com/fxml/1">
     <icons>
         <Image url="@/images/address_book_32.png" />
     </icons>
@@ -27,6 +29,11 @@
                         </VBox>
                     </children>
                 </AnchorPane>
+            <ButtonBar prefHeight="40.0" prefWidth="200.0">
+              <buttons>
+                <Button fx:id="closeButton" onAction="#closeButtonAction" mnemonicParsing="false" text="OK" />
+              </buttons>
+            </ButtonBar>
             </VBox>
         </Scene>
     </scene>

--- a/src/main/resources/view/NightDebriefWindow.fxml
+++ b/src/main/resources/view/NightDebriefWindow.fxml
@@ -28,8 +28,8 @@
                                 <Insets left="10" right="10" top="10" />
                             </padding>
                             <StackPane fx:id="taskListPanelPlaceholder" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" VBox.vgrow="ALWAYS" />
-                            <StackPane fx:id="resultDisplayPlaceholder" maxHeight="50" minHeight="50"
-                                       prefHeight="50" styleClass="pane-with-border" VBox.vgrow="NEVER">
+                            <StackPane fx:id="resultDisplayPlaceholder" maxHeight="100" minHeight="100"
+                                       prefHeight="100" styleClass="pane-with-border" VBox.vgrow="NEVER">
                                 <padding>
                                     <Insets bottom="5" left="10" right="10" top="5" />
                                 </padding>

--- a/src/main/resources/view/NightDebriefWindow.fxml
+++ b/src/main/resources/view/NightDebriefWindow.fxml
@@ -8,7 +8,7 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.stage.*?>
 
-<fx:root minHeight="540" minWidth="400" title="Morning Call" type="javafx.stage.Stage"
+<fx:root minHeight="540" minWidth="400" title="Night Debrief" type="javafx.stage.Stage"
          xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml">
     <icons>
         <Image url="@/images/address_book_32.png" />
@@ -35,9 +35,9 @@
                                 </padding>
                             </StackPane>
                             <ButtonBar maxHeight="40.0" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="40.0" prefWidth="80.0">
-                               <buttons>
-                                 <Button fx:id="closeButton" alignment="CENTER" contentDisplay="CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="0.0" mnemonicParsing="false" onAction="#closeButtonAction" prefHeight="31.0" text="OK" textAlignment="CENTER" />
-                               </buttons>
+                                <buttons>
+                                    <Button fx:id="closeButton" alignment="CENTER" contentDisplay="CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="0.0" mnemonicParsing="false" onAction="#closeButtonAction" prefHeight="31.0" text="OK" textAlignment="CENTER" />
+                                </buttons>
                             </ButtonBar>
                         </VBox>
                     </children>

--- a/src/test/java/seedu/jelphabot/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/jelphabot/logic/LogicManagerTest.java
@@ -91,6 +91,16 @@ public class LogicManagerTest {
         assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredTaskList().remove(0));
     }
 
+    @Test
+    public void getFilteredByCompleteTaskList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredByCompleteTaskList().remove(0));
+    }
+
+    @Test
+    public void getFilteredByIncompleteTaskList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredByIncompleteTaskList().remove(0));
+    }
+
     /**
      * Executes the command and confirms that - no exceptions are thrown <br>
      * - the feedback message is equal to {@code expectedMessage} <br>

--- a/src/test/java/seedu/jelphabot/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/jelphabot/logic/commands/AddCommandTest.java
@@ -93,6 +93,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public GuiSettings getPopUpWindowGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setGuiSettings(GuiSettings guiSettings) {
             throw new AssertionError("This method should not be called.");
         }
@@ -139,6 +144,16 @@ public class AddCommandTest {
 
         @Override
         public ObservableList<Task> getFilteredTaskList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Task> getFilteredByIncompleteTaskList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Task> getFilteredByCompleteTaskList() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/jelphabot/model/ModelManagerTest.java
+++ b/src/test/java/seedu/jelphabot/model/ModelManagerTest.java
@@ -95,6 +95,15 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void getFilteredByCompleteTaskList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredByCompleteTaskList().remove(0));
+    }
+
+    @Test
+    public void getFilteredByIncompleteTaskList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredByIncompleteTaskList().remove(0));
+    }
+    @Test
     public void equals() {
         JelphaBot addressBook = new JelphaBotBuilder().withTask(ASSESSMENT).withTask(BOOK_REPORT).build();
         JelphaBot differentJelphaBot = new JelphaBot();

--- a/src/test/java/seedu/jelphabot/model/ModelManagerTest.java
+++ b/src/test/java/seedu/jelphabot/model/ModelManagerTest.java
@@ -15,8 +15,10 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.ObservableList;
 import seedu.jelphabot.commons.core.GuiSettings;
 import seedu.jelphabot.model.task.DescriptionContainsKeywordsPredicate;
+import seedu.jelphabot.model.task.Task;
 import seedu.jelphabot.testutil.JelphaBotBuilder;
 
 public class ModelManagerTest {
@@ -101,7 +103,8 @@ public class ModelManagerTest {
 
     @Test
     public void getFilteredByIncompleteTaskList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredByIncompleteTaskList().remove(0));
+        ObservableList<Task> filteredByIncompleteTaskList = modelManager.getFilteredByIncompleteTaskList();
+        assertThrows(UnsupportedOperationException.class, () -> filteredByIncompleteTaskList.remove(0));
     }
     @Test
     public void equals() {


### PR DESCRIPTION
Implemented the morning call feature as a separate popup window that is shown upon app startup. Both windows (MorningCallWindow and MainWindow) are loaded upon startup. Styling and layout adapted from MainWindow. For now, it lists ALL incomplete tasks in the task list, as well as a ResultDisplay (also adapted from MainWindow) to flag to the user that the shown window contains the list of incomplete tasks. Provides a button for the user to click to close the window, which will then result in the MainWindow behind being shown.

For NightDebrief, the styling is the same as that of MorningCallWindow. The NightDebriefWindow is opened upon the closure of the app (after the "exit" command is issued), and displays the list of tasks that are completed by the user so far.